### PR TITLE
pdks: ihp-sg13*: Drop the comments from pdk.yml

### DIFF
--- a/pdks/ihp-sg13cmos5l/pdk.yml
+++ b/pdks/ihp-sg13cmos5l/pdk.yml
@@ -118,8 +118,6 @@ decks:
     path: decks/antenna.yml
     description: Antenna rules (M1-M4 + TopMetal1 stack)
 
-# The M1–M4 + TopVia1 + TopMetal1 stack: TopVia1 lands on Metal4 (no Metal5/Via4,
-# no TopVia2/TopMetal2).
 connectivity:
   - connector: Cont
     layers: [GatPoly]
@@ -144,14 +142,11 @@ connectivity:
   - connector: TopVia1
     layers: [TopMetal1]
 
-# CMOS5L-only recognition (appended after the inherited SG13G2 virtual layers).
 virtual_layers:
-  # Pad.i: a dfpad opening without TopMetal1 underneath (TM1 is the pad metal here).
   - name: DfpadNoTopMetal1
     op: difference
     mode: lazy
     layers: [dfpad, TopMetal1]
-  # Chapter 8 digital splits: Cnt.c and NW.f1 relax inside a DigiBnd region.
   - name: ContOnActivAna
     op: not_interacting
     mode: lazy

--- a/pdks/ihp-sg13g2/pdk.yml
+++ b/pdks/ihp-sg13g2/pdk.yml
@@ -148,8 +148,6 @@ decks:
     path: decks/mim.yml
     description: MIM capacitor
 
-# Connect graph for net extraction (antenna checks, §7.1).  Ordered: a net-aware check
-# can partition over any prefix (e.g. "everything up to Metal2") for the per-level ratio.
 connectivity:
   - connector: Cont
     layers: [GatPoly]
@@ -190,7 +188,6 @@ virtual_layers:
       - Passiv.sbump
       - Passiv.pillar
       - dfpad
-  # Device recognition: pad = passivation-type marker AND dfpad (intersection, not union).
   - name: SBumpPad
     op: intersection
     layers:
@@ -201,7 +198,6 @@ virtual_layers:
     layers:
       - Passiv.pillar
       - dfpad
-  # Padb.f/Padc.f: only circles/octagons are allowed passivation-opening shapes.
   - name: SBumpPadBadShape
     op: not_circle_or_octagon
     mode: lazy
@@ -210,8 +206,6 @@ virtual_layers:
     op: not_circle
     mode: lazy
     layers: [CuPillarPad]
-  # Padc.d: pad-anchored 30 µm reach — grows the sparse pad instead of giving dense Activ
-  # a 30 µm halo. radius 29.995 + grow's 5 dbu margin = an exact 30.000 reach.
   - name: CuPillarPadGrown
     op: grow
     mode: lazy
@@ -222,8 +216,6 @@ virtual_layers:
     mode: lazy
     layers: [CuPillarPadGrown, SealActiv]
 
-  # The seal ring is a continuous Cont/via band that legitimately fails exact_width;
-  # checking the NoSealring variant skips it without globally silencing the periphery.
   - name: ContNoSealring
     op: difference
     mode: lazy
@@ -256,25 +248,20 @@ virtual_layers:
     mode: lazy
     layers: [TopVia2, EdgeSeal]
 
-  # Passiv inside the (hole-filled) seal ring — Pad.c isn't checked outside the seal.
   - name: PassivInSeal
     op: inside
     layers: [Passiv, EdgeSeal]
 
-  # TM2.bR (wide-line spacing) is not checked inside inductor (IND) regions.
   - name: TopMetal2NotIND
     op: difference
     mode: lazy
     layers: [TopMetal2, IND]
 
-  # Salicidable area (diffusion + gate poly); Sal.d treats them together.
   - name: ActivOrGatPoly
     op: union
     mode: lazy
     layers: [Activ, GatPoly]
 
-  # Square vs. bar contacts, on the seal-excluded Conts (else the seal band reads as one
-  # giant bar). Used by Cnt.e–Cnt.j (square) and CntB.e–CntB.j (bar).
   - name: ContSquare
     op: square
     mode: lazy
@@ -292,9 +279,6 @@ virtual_layers:
     op: intersection
     mode: lazy
     layers: [ContSquare, Activ]
-  # SRAM macros use foundry-qualified bit cells that waive several FEOL rules. The
-  # exclusion goes on the side that makes the rule silent (measured/enclosed, or the
-  # well side for spacings) — excluding the enclosing side instead would fabricate FPs.
   - name: ContOnActivNoSRAM
     op: not_interacting
     mode: lazy
@@ -325,8 +309,6 @@ virtual_layers:
     mode: lazy
     layers: [ContBar, Activ, pSD]
 
-  # P+/N+ Activ (∩pSD/∩nSD), split by ThickGateOx. NW.c: NWell enclosure of P+ tap.
-  # NW.d: NWell space to external N+ (min_space already skips overlapping shapes).
   - name: PsdActivInNWell
     op: intersection
     mode: lazy
@@ -351,8 +333,6 @@ virtual_layers:
     op: difference
     mode: lazy
     layers: [NsdActiv, ThickGateOx]
-  # Full derived N+ for NW.d/d1: undoped Activ is N+ by default, nSD:block suppresses it,
-  # drawn nSD overrides the block — drawn-nSD-only would miss almost every real N+ region.
   - name: ActivDefaultN
     op: difference
     mode: lazy
@@ -369,12 +349,10 @@ virtual_layers:
     op: intersection
     mode: lazy
     layers: [NActFull, ThickGateOx]
-  # N+ diffusion for the latch-up deck: IHP marks only P+ (pSD), so N+ = Activ − pSD.
   - name: NActiv
     op: difference
     mode: lazy
     layers: [Activ, pSD]
-  # NWell tie (N+Activ in NWell — no NMOS lives in an NWell, so this is all tap).
   - name: NActivInNWell
     op: intersection
     mode: lazy
@@ -391,8 +369,6 @@ virtual_layers:
     op: difference
     mode: lazy
     layers: [NActiv, NWell]
-  # Chapter 8 DigiBnd: inside the digital boundary, the HV NWell rules relax to LV values
-  # (NW.c1/d1/e1 → .dig at 0.31/0.31/0.24).
   - name: PsdActivInNWellTGOAna
     op: not_interacting
     mode: lazy
@@ -417,19 +393,14 @@ virtual_layers:
     op: interacting
     mode: lazy
     layers: [NActivInNWellTGO, DigiBnd]
-  # pSD.c requires pSD to enclose only the NWell Activ parts that actually touch it
-  # (bare N+ NWell taps are skipped).
   - name: ActivInNWell
     op: intersection
     mode: lazy
     layers: [Activ, NWell]
-  # pSD.i/i1/j/j1 ignore SRAM bit cells.
   - name: pSDNoSRAM
     op: difference
     mode: lazy
     layers: [pSD, SRAM]
-  # pSD.g: abutted-tie taps (NWell/PWell tie Activ minus Gate, outside SRAM) below
-  # 0.09 µm² can't form a reliable electrical tie.
   - name: Gate
     op: intersection
     mode: lazy
@@ -450,9 +421,6 @@ virtual_layers:
     op: not_interacting
     mode: lazy
     layers: [PTapNoGate, SRAM]
-  # pSD.e: an abutted-tie P+ overlap sliver must be ≥0.30 wide at ONE position (inverse of
-  # min_width) — implemented as morphological open: a sliver that vanishes under open(r)
-  # has no ≥2r-wide spot. r = 0.149 (not 0.150) so exactly-0.30 survives, ≤0.295 dies.
   - name: ActivNoSRAM
     op: difference
     mode: lazy
@@ -482,13 +450,11 @@ virtual_layers:
     op: not_interacting
     mode: lazy
     layers: [TieOverlap, TieOverlapOpened]
-  # LU.c/d reference only a tie's own contacts, to stay sparse.
   - name: ContOnNWellTie
     op: intersection
     mode: lazy
     layers: [Cont, NActivInNWell]
 
-  # P+/N+ Activ in the PWell (substrate) region, for PWB.e/e1/f/f1.
   - name: PsdActiv
     op: intersection
     mode: lazy
@@ -522,9 +488,6 @@ virtual_layers:
     mode: lazy
     layers: [PsdActivInPWell, ThickGateOx]
 
-  # pSD.f: an abutted NWell-tie N-tap must extend ≥0.30 past the P+ abutment at ONE
-  # position. grow(0.0) turns the zero-area abutment into an overlap (grow's 5 dbu
-  # margin); grow(0.29) reaches 0.295, so a surviving NTapDeep sliver means >0.295 deep.
   - name: NActivX1
     op: intersection
     mode: lazy
@@ -555,8 +518,6 @@ virtual_layers:
     op: not_interacting
     mode: lazy
     layers: [AbuttedNTap, NTapDeep]
-  # pSD.c1: Activ touching pSD, clipped to the implicit PWell (chip minus NWell/
-  # PWell:block), outside the edge seal.
   - name: ActivTouchPsd
     op: interacting
     mode: lazy
@@ -566,8 +527,6 @@ virtual_layers:
     mode: lazy
     layers: [ActivTouchPsd, NWell, PWell.block, EdgeSeal]
 
-  # --- Poly-resistor recognition (chapter 6, §6.x) ---
-  # Resistor body: GatPoly or the dedicated PolyRes layer.
   - name: GatPolyRes
     op: union
     mode: lazy
@@ -576,7 +535,6 @@ virtual_layers:
     op: difference
     mode: lazy
     layers: [SalBlock, Recog.esd, nSD.block]
-  # pSD ∩ nSD marks the Rhigh body (nSD is drawn only inside Rhigh resistors).
   - name: pSDnSD
     op: intersection
     mode: lazy
@@ -589,7 +547,6 @@ virtual_layers:
     op: intersection
     mode: lazy
     layers: [SalBlock, RhighA]
-  # Rsil (RES/silicide resistor): drops bodies touching NWell or nBuLay.
   - name: RsilBase
     op: intersection
     mode: lazy
@@ -610,9 +567,6 @@ virtual_layers:
     op: covering
     mode: lazy
     layers: [GatPolyRes, Rsil]
-  # Rsil.c: RES (a back-annotation marker) must not extend past the resistor's GatPoly
-  # body at all, except where a Cont lands on the protrusion. Direction confirmed against
-  # the real tool: RES past GatPoly flags; GatPoly past RES does not.
   - name: RsilResProtrusion
     op: difference
     mode: lazy
@@ -621,7 +575,6 @@ virtual_layers:
     op: not_interacting
     mode: lazy
     layers: [RsilResProtrusion, Cont]
-  # Rppd (P+ poly resistor): GatPoly under pSD+SalBlock not touching diffusion/nSD.
   - name: Rppd0
     op: intersection
     mode: lazy
@@ -642,15 +595,10 @@ virtual_layers:
     op: intersection
     mode: lazy
     layers: [SalBlock, RppdAll]
-  # Rppd.c: the relevant Cont is only the one on the resistor's own GatPoly end-cap, not
-  # any Cont merely within the EXTBlock.
   - name: RppdCont
     op: intersection
     mode: lazy
     layers: [Cont, GPRppdExtended]
-  # Rppd.c's max-space half ("Cont within 0.20 of SalBlock") is a whole-region touch test,
-  # not an area-coverage test: grow SalBlockRppd by the rule value, flag Conts that still
-  # don't touch it.
   - name: SalBlockRppdGrown
     op: grow
     mode: lazy
@@ -664,7 +612,6 @@ virtual_layers:
     op: covering
     mode: lazy
     layers: [GatPolyRes, RhighA]
-  # Rhi.d: same Cont-on-GatPoly pattern as Rppd.c, for the Rhigh body.
   - name: RhighCont
     op: intersection
     mode: lazy
@@ -678,8 +625,6 @@ virtual_layers:
     op: not_interacting
     mode: lazy
     layers: [RhighCont, SalBlockRhighGrown]
-  # Rhi.b: drawn nSD sticking out past pSD, flagged where it touches the Rhigh
-  # recognition (grown a hair so zero-area abutment is detectable).
   - name: NsdMismatch
     op: difference
     mode: lazy
@@ -702,10 +647,6 @@ virtual_layers:
     mode: lazy
     layers: [NsdMismatch, RhighRecogGrown]
 
-  # --- Bipolar npn (chapter 6.1) recognition ---
-  # NPN substrate tie: the interior (`holes`) of its pSD ring, labelled "npn*".  radius =
-  # max expected tie-ring extent (the hole only materialises where the whole ring
-  # assembles in one tile bucket).
   - name: PsdRingHole
     op: holes
     mode: lazy
@@ -737,7 +678,6 @@ virtual_layers:
     op: difference
     mode: lazy
     layers: [GatPoly, SRAM]
-  # Device flavours by exact TRANS text label.
   - name: TransG2
     op: with_text
     mode: lazy
@@ -766,8 +706,6 @@ virtual_layers:
     mode: lazy
     layers: [EmWind, TransG2V]
 
-  # --- Schottky diode (chapter 6.7) recognition ---
-  # schottky_nbl1 = ContBar enclosed by (SalBlock and nSD:block and PWell:block and nBuLay).
   - name: SchottkyBlock
     op: intersection
     mode: lazy
@@ -777,8 +715,6 @@ virtual_layers:
     mode: lazy
     layers: [ContBar, SchottkyBlock]
 
-  # --- Isolated-NMOS (nmosi) recognition (chapter 6) ---
-  # Iso-PWell-Activ = Activ inside the buried layer but outside any NWell / PWell:block.
   - name: NWellOrPWellBlk
     op: union
     mode: lazy
@@ -799,16 +735,11 @@ virtual_layers:
     op: interacting
     mode: lazy
     layers: [nSD.block, IsoPWellAct]
-  # nmosi.c anchor: only ring-shaped NWells count — a plain NWell near some iso-PWell
-  # Activ is not the isolation ring.
   - name: NWellRing
     op: with_holes
     mode: lazy
     radius: 10.0
     layers: [NWell]
-  # nmosi.g: SalBlock must extend ≥0.15 past nSD:block wherever the adjacent ground is
-  # still Activ. grow radius 0.145 + its 5 dbu margin = an effective 0.150 band, so a
-  # compliant 0.15 extension yields an empty band while 0.145 leaves a sliver.
   - name: SalBlockIso
     op: interacting
     mode: lazy
@@ -827,7 +758,6 @@ virtual_layers:
     mode: lazy
     layers: [NSDBlockUncov, Activ]
 
-  # AFil.j: Activ:filler inside PWell:block, enclosed by (nSD:block ∩ SalBlock) by 0.25 µm.
   - name: ActivFillerInPWellBlock
     op: intersection
     mode: lazy
@@ -837,7 +767,6 @@ virtual_layers:
     mode: lazy
     layers: [nSD.block, SalBlock]
 
-  # ThickGateOx helpers, for the TGO.b/d "space … outside TGO" rules.
   - name: GatPolyOverActiv
     op: intersection
     mode: lazy
@@ -859,9 +788,6 @@ virtual_layers:
     mode: lazy
     layers: [GatPolyOverActiv, ThickGateOx]
 
-  # Same-net merge for NW.b/NBL.b "different net" spacing: a morphological close joins
-  # regions whose gap is below the same-net distance (half the close radius), so
-  # min_space on the result only flags genuinely separate (different-net) regions.
   - name: NWellMerged
     op: close
     mode: lazy
@@ -886,8 +812,6 @@ virtual_layers:
     radius: 0.75
     layers: [nBuLay]
 
-  # Seal-ring rings: each conductor inside the EdgeSeal frame. Seal.a/c/c1/c2/c3 check
-  # their width; Seal.d the Activ-ring enclosure of the via rings.
   - name: SealActiv
     op: intersection
     mode: lazy
@@ -953,26 +877,20 @@ virtual_layers:
     mode: lazy
     layers: [TopVia2, EdgeSeal]
 
-  # Passivation ring outside the seal (Seal.e/f), approximated as Passiv not interacting
-  # EdgeSeal since `with_holes` can't be a virtual layer here (a chip-perimeter hole isn't
-  # tile-local). Caveat: a thin non-ring Passiv shape outside the seal would over-flag.
   - name: RingPassiv
     op: not_interacting
     mode: lazy
     layers: [Passiv, EdgeSeal]
 
-  # Pad opening, for Pad.a1/d width/space rules.
   - name: PassivDfpad
     op: intersection
     mode: lazy
     layers: [Passiv, dfpad]
-  # Pad.i: a dfpad opening drawn without TopMetal2 underneath is a forbidden marker error.
   - name: DfpadNoTopMetal2
     op: difference
     mode: lazy
     layers: [dfpad, TopMetal2]
 
-  # Gate-length-by-device helpers (Gat.a1–a4): split by S/D implant and ThickGateOx.
   - name: GatPolyOverNsdActiv
     op: intersection
     mode: lazy
@@ -998,7 +916,6 @@ virtual_layers:
     mode: lazy
     layers: [GatPolyOverPsdActiv, ThickGateOx]
 
-  # Metal with the slit-exempt regions removed (pads/MIM/IND), for Slt.c/Slt.i.
   - name: Metal1NoExempt
     op: difference
     mode: lazy
@@ -1027,7 +944,6 @@ virtual_layers:
     op: difference
     mode: lazy
     layers: [TopMetal2, Passiv, MIM, IND]
-  # Slt.e: drawn slits must not land on a pad (every dfpad shape touching a Passiv opening).
   - name: PadDfpad
     op: interacting
     mode: lazy
@@ -1061,10 +977,6 @@ virtual_layers:
     mode: lazy
     layers: [TopMetal2.slit, PadDfpad]
 
-  # --- Antenna (§7.1) ---
-  # P+ diffusion contact area (Activ that is not gate, and is pSD). Ant.i flags a diode on
-  # it landing in the PWell (neither NWell nor an explicit PWell.block) — a p-diode may
-  # only sit in an NWell.
   - name: ActivNotGat
     op: difference
     mode: lazy
@@ -1082,8 +994,6 @@ virtual_layers:
     mode: lazy
     layers: [AntDpDiode, Recog.esd, NWell, PWell.block]
 
-  # Antenna ratio helpers (Ant.b/e, Ant.d/f): a net's diffusion diode is any non-gate
-  # Activ contact, the discharge path that relaxes the ratio limit.
   - name: NActivCon
     op: difference
     mode: lazy
@@ -1092,14 +1002,11 @@ virtual_layers:
     op: union
     mode: lazy
     layers: [NActivCon, PActivCon]
-  # Ant.a: GatPoly routed over field oxide (not over Activ).
   - name: AntPolyField
     op: difference
     mode: lazy
     layers: [GatPoly, Activ]
 
-  # Protection-diode devices (Ant.g): an n-diode is an n-diffusion under a diode marker
-  # outside the NWell; a p-diode is a p-diffusion marker inside the NWell.
   - name: AntDnDiode
     op: intersection
     mode: lazy
@@ -1114,7 +1021,6 @@ virtual_layers:
     layers: [PActivCon, Recog.diode, NWell]
 
 layers:
-  # --- Front-end ---
   - name: Activ
     gds_layer: 1
     gds_datatype: 0
@@ -1299,7 +1205,6 @@ layers:
     gds_layer: 117
     gds_datatype: 0
 
-  # --- Contacts ---
   - name: Cont
     gds_layer: 6
     gds_datatype: 0
@@ -1313,7 +1218,6 @@ layers:
     gds_layer: 6
     gds_datatype: 26
 
-  # --- Metal stack ---
   - name: Metal1
     gds_layer: 8
     gds_datatype: 0
@@ -1597,7 +1501,6 @@ layers:
     gds_layer: 67
     gds_datatype: 34
 
-  # --- Top metals ---
   - name: TopVia1
     gds_layer: 125
     gds_datatype: 0
@@ -1653,7 +1556,6 @@ layers:
   - name: TopMetal1.dt30
     gds_layer: 126
     gds_datatype: 30
-    # seal-periphery (unspecified by IHP)
 
   - name: TopVia2
     gds_layer: 133
@@ -1710,9 +1612,7 @@ layers:
   - name: TopMetal2.dt30
     gds_layer: 134
     gds_datatype: 30
-    # seal-periphery (unspecified by IHP)
 
-  # --- Passivation ---
   - name: Passiv
     gds_layer: 9
     gds_datatype: 0
@@ -1745,7 +1645,6 @@ layers:
     gds_layer: 146
     gds_datatype: 0
 
-  # --- Bipolar ---
   - name: BiWind
     gds_layer: 3
     gds_datatype: 0
@@ -1798,7 +1697,6 @@ layers:
     gds_layer: 35
     gds_datatype: 0
 
-  # --- HV / special ---
   - name: IND
     gds_layer: 27
     gds_datatype: 0
@@ -1878,7 +1776,6 @@ layers:
     gds_layer: 152
     gds_datatype: 0
 
-  # --- Bond / packaging ---
   - name: dfpad
     gds_layer: 41
     gds_datatype: 0
@@ -1970,7 +1867,6 @@ layers:
     gds_layer: 23
     gds_datatype: 0
 
-  # --- Photonics ---
   - name: GraphBot
     gds_layer: 78
     gds_datatype: 0
@@ -2044,7 +1940,6 @@ layers:
     gds_layer: 86
     gds_datatype: 23
 
-  # --- SNS ---
   - name: SNSArms
     gds_layer: 137
     gds_datatype: 0
@@ -2076,7 +1971,6 @@ layers:
     gds_layer: 147
     gds_datatype: 0
 
-  # --- Antenna / auxiliary metals ---
   - name: AntMetal1
     gds_layer: 132
     gds_datatype: 0
@@ -2087,7 +1981,6 @@ layers:
     gds_layer: 83
     gds_datatype: 0
 
-  # --- NoRCX exclusions ---
   - name: NoRCX.m1sub
     gds_layer: 148
     gds_datatype: 123
@@ -2155,7 +2048,6 @@ layers:
     gds_layer: 148
     gds_datatype: 301
 
-  # --- Exchange / PDK exchange layers ---
   - name: Exchange0
     gds_layer: 190
     gds_datatype: 0
@@ -2217,7 +2109,6 @@ layers:
     gds_layer: 194
     gds_datatype: 25
 
-  # --- Miscellaneous ---
   - name: TRANS
     gds_layer: 26
     gds_datatype: 0
@@ -2294,7 +2185,6 @@ layers:
     gds_layer: 189
     gds_datatype: 4
 
-  # --- Miscellaneous ---
   - name: PEmWind
     gds_layer: 11
     gds_datatype: 0


### PR DESCRIPTION
The PDK definition is data, so keep it plain dicts and lists. The SPDX/REUSE header stays: REUSE.toml has no pdks/** annotation, so it is the only thing declaring the licence for these files.

What the removed comments explained - the same-net close merge, the device-recognition virtual layers, the seal-ring rings - is already in docs/source/pdks/ and docs/source/virtual-ops.rst.